### PR TITLE
Introduce `gravitational/teleport-actions/auth` action for `tsh` and `tctl`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,10 @@ repos:
         name: package-auth-k8s
         entry: hooks/package-auth-k8s.sh
         language: script
+      - id: package-auth
+        name: package-auth
+        entry: hooks/package-auth.sh
+        language: script
       - id: lint
         name: lint
         entry: hooks/lint.sh

--- a/README.md
+++ b/README.md
@@ -52,6 +52,46 @@ steps:
       version: 11.0.3
 ```
 
+### `@gravitational/teleport-actions/auth`
+
+`auth` uses Teleport Machine ID to generate a set of credentials which can be
+used with other Teleport client tools such as `tsh` and `tctl`.
+
+The action has the following outputs:
+
+- `identity-file`: the path to the identity file which can be used with `tctl` and `tsh`.
+
+Pre-requisites:
+
+- Teleport 11 or above must be used.
+- Teleport binaries must already be installed in the job environment.
+- You must have created a bot and created a GitHub join token that allows that
+  bot to join.
+- A Linux based runner.
+
+Example usage:
+
+```yaml
+steps:
+  - name: Install Teleport
+    uses: gravitational/teleport-actions/setup@v1
+    with:
+      version: 11.0.3
+  - name: Authorize against Teleport
+    id: auth
+    uses: gravitational/teleport-actions/auth@v1
+    with:
+      # Specify the publically accessible address of your Teleport proxy.
+      proxy: tele.example.com:443
+      # Specify the name of the join token for your bot.
+      token: my-github-join-token
+      # Specify the length of time that the generated credentials should be
+      # valid for. This is optional and defaults to "1h"
+      certificate-ttl: 1h
+  - name: List nodes
+    run: tsh -i ${{ steps.auth.outputs.identity-file }} --proxy tele.example.com:443 ls
+```
+
 ### `@gravitational/teleport-actions/auth-k8s`
 
 `auth-k8s` uses Teleport Machine ID to generate an authorized Kubernetes client
@@ -70,7 +110,7 @@ Pre-requisites:
   <https://goteleport.com/docs/kubernetes-access/getting-started/>
 - You must have created a bot with a role with access to your Kubernetes cluster
   and create a GitHub join token that allows that bot to join.
-- A Linux based runner
+- A Linux based runner.
 
 Example usage:
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ steps:
       # Specify the publically accessible address of your Teleport proxy.
       proxy: tele.example.com:443
       # Specify the name of the join token for your bot.
-      token: my-github-join-token
+      token: my-github-join-token-name
       # Specify the length of time that the generated credentials should be
       # valid for. This is optional and defaults to "1h"
       certificate-ttl: 1h
@@ -133,7 +133,7 @@ steps:
       # Specify the publically accessible address of your Teleport proxy.
       proxy: tele.example.com:443
       # Specify the name of the join token for your bot.
-      token: my-github-join-token
+      token: my-github-join-token-name
       # Specify the length of time that the generated credentials should be
       # valid for. This is optional and defaults to "1h"
       certificate-ttl: 1h

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ steps:
 
 ### `@gravitational/teleport-actions/auth`
 
+> :warning: **This is a preview action.** No v1 has been released yet. We hope to ship this in coming weeks.
+
 `auth` uses Teleport Machine ID to generate a set of credentials which can be
 used with other Teleport client tools such as `tsh` and `tctl`.
 
@@ -79,7 +81,7 @@ steps:
       version: 11.0.3
   - name: Authorize against Teleport
     id: auth
-    uses: gravitational/teleport-actions/auth@v1
+    uses: gravitational/teleport-actions/auth@main
     with:
       # Specify the publically accessible address of your Teleport proxy.
       proxy: tele.example.com:443

--- a/README.md
+++ b/README.md
@@ -88,9 +88,14 @@ steps:
       # Specify the length of time that the generated credentials should be
       # valid for. This is optional and defaults to "1h"
       certificate-ttl: 1h
-  - name: List nodes
-    run: tsh -i ${{ steps.auth.outputs.identity-file }} --proxy tele.example.com:443 ls
+  - name: List nodes (tsh)
+    run: tsh -i ${{ steps.auth.outputs.identity-file }} ls
+  - name: List nodes (tctl)
+    run: tctl -i ${{ steps.auth.outputs.identity-file }} --auth-server tele.example.com:443 nodes ls
 ```
+
+Note that `tsh` and `tctl` require the flag pointing at the identity file and
+`tctl` also requires the address of the Proxy or Auth Server to be provided.
 
 ### `@gravitational/teleport-actions/auth-k8s`
 

--- a/auth/action.yml
+++ b/auth/action.yml
@@ -1,0 +1,17 @@
+name: 'Teleport Auth'
+description: 'Uses Machine ID to fetch credentials for use with `tctl` and `tsh`. Automatically configures `tctl` and `tsh` to use these credentials in following steps.'
+author: 'Gravitational Inc.'
+inputs:
+  # These inputs are global to all Teleport tbot helper actions.
+  token:
+    description: 'Specify the Teleport token to use to join.'
+    required: true
+  proxy:
+    description: 'Specify the address of your Teleport Proxy.'
+    required: true
+  certificate-ttl:
+    description: 'Specify the length that the generated credentials should be valid for. Defaults to "1h"'
+    required: false
+runs:
+  using: 'node16'
+  main: '../dist/auth/index.js'

--- a/auth/action.yml
+++ b/auth/action.yml
@@ -1,6 +1,6 @@
 name: 'Teleport Auth'
 description: 'Uses Machine ID to fetch credentials for use with `tctl` and `tsh`. Automatically configures `tctl` and `tsh` to use these credentials in following steps.'
-author: 'Gravitational Inc.'
+author: 'Gravitational, Inc.'
 inputs:
   # These inputs are global to all Teleport tbot helper actions.
   token:

--- a/auth/index.ts
+++ b/auth/index.ts
@@ -19,6 +19,10 @@ async function run() {
 
   const configPath = await tbot.writeConfiguration(config);
   await tbot.execute(configPath);
-  core.setOutput('identity-file', path.join(destinationPath, 'identity'));
+
+  const identityFilePath = path.join(destinationPath, 'identity');
+  core.setOutput('identity-file', identityFilePath);
+  core.exportVariable('TELEPORT_PROXY', sharedInputs.proxy);
+  core.exportVariable('TELEPORT_IDENTITY_FILE', identityFilePath);
 }
 run().catch(core.setFailed);

--- a/auth/index.ts
+++ b/auth/index.ts
@@ -5,39 +5,20 @@ import * as core from '@actions/core';
 import * as tbot from '../lib/tbot';
 import * as io from '../lib/io';
 
-interface Inputs {
-  kubernetesCluster: string;
-}
-
-function getInputs(): Inputs {
-  return {
-    kubernetesCluster: core.getInput('kubernetes-cluster', {
-      required: true,
-    }),
-  };
-}
-
 async function run() {
-  const inputs = getInputs();
   const sharedInputs = tbot.getSharedInputs();
   const config = tbot.baseConfigurationFromSharedInputs(sharedInputs);
 
-  // Inject a destination for the Kubernetes cluster credentials
   const destinationPath = await io.makeTempDirectory();
   config.destinations.push({
     directory: {
       path: destinationPath,
     },
     roles: [], // Use all assigned to bot,
-    kubernetes_cluster: inputs.kubernetesCluster,
   });
 
   const configPath = await tbot.writeConfiguration(config);
   await tbot.execute(configPath);
-
-  core.exportVariable(
-    'KUBECONFIG',
-    path.join(destinationPath, '/kubeconfig.yaml')
-  );
+  core.setOutput('identity-file', path.join(destinationPath, 'identity'));
 }
 run().catch(core.setFailed);

--- a/dist/auth-k8s/index.js
+++ b/dist/auth-k8s/index.js
@@ -4175,10 +4175,11 @@ function baseConfigurationFromSharedInputs(inputs) {
 exports.baseConfigurationFromSharedInputs = baseConfigurationFromSharedInputs;
 function writeConfiguration(config) {
     return __awaiter(this, void 0, void 0, function* () {
-        core.debug('Writing tbot configuration:\n' + yaml.stringify(config));
         const tempDir = yield io.makeTempDirectory();
         const configPath = path.join(tempDir, 'bot-config.yaml');
         const data = yaml.stringify(config);
+        core.debug('Writing tbot configuration to ' + configPath);
+        core.debug('Configuration value:\n' + data);
         yield fs.writeFile(configPath, data);
         return configPath;
     });

--- a/dist/auth/index.js
+++ b/dist/auth/index.js
@@ -4013,7 +4013,10 @@ function run() {
         });
         const configPath = yield tbot.writeConfiguration(config);
         yield tbot.execute(configPath);
-        core.setOutput('identity-file', path_1.default.join(destinationPath, 'identity'));
+        const identityFilePath = path_1.default.join(destinationPath, 'identity');
+        core.setOutput('identity-file', identityFilePath);
+        core.exportVariable('TELEPORT_PROXY', sharedInputs.proxy);
+        core.exportVariable('TELEPORT_IDENTITY_FILE', identityFilePath);
     });
 }
 run().catch(core.setFailed);

--- a/dist/auth/index.js
+++ b/dist/auth/index.js
@@ -4165,10 +4165,11 @@ function baseConfigurationFromSharedInputs(inputs) {
 exports.baseConfigurationFromSharedInputs = baseConfigurationFromSharedInputs;
 function writeConfiguration(config) {
     return __awaiter(this, void 0, void 0, function* () {
-        core.debug('Writing tbot configuration:\n' + yaml.stringify(config));
         const tempDir = yield io.makeTempDirectory();
         const configPath = path.join(tempDir, 'bot-config.yaml');
         const data = yaml.stringify(config);
+        core.debug('Writing tbot configuration to ' + configPath);
+        core.debug('Configuration value:\n' + data);
         yield fs.writeFile(configPath, data);
         return configPath;
     });

--- a/dist/auth/index.js
+++ b/dist/auth/index.js
@@ -3955,7 +3955,7 @@ exports.debug = debug; // for test
 
 /***/ }),
 
-/***/ 7410:
+/***/ 6099:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -4000,30 +4000,20 @@ const path_1 = __importDefault(__nccwpck_require__(1017));
 const core = __importStar(__nccwpck_require__(2186));
 const tbot = __importStar(__nccwpck_require__(2229));
 const io = __importStar(__nccwpck_require__(9317));
-function getInputs() {
-    return {
-        kubernetesCluster: core.getInput('kubernetes-cluster', {
-            required: true,
-        }),
-    };
-}
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
-        const inputs = getInputs();
         const sharedInputs = tbot.getSharedInputs();
         const config = tbot.baseConfigurationFromSharedInputs(sharedInputs);
-        // Inject a destination for the Kubernetes cluster credentials
         const destinationPath = yield io.makeTempDirectory();
         config.destinations.push({
             directory: {
                 path: destinationPath,
             },
-            roles: [],
-            kubernetes_cluster: inputs.kubernetesCluster,
+            roles: [], // Use all assigned to bot,
         });
         const configPath = yield tbot.writeConfiguration(config);
         yield tbot.execute(configPath);
-        core.exportVariable('KUBECONFIG', path_1.default.join(destinationPath, '/kubeconfig.yaml'));
+        core.setOutput('identity-file', path_1.default.join(destinationPath, 'identity'));
     });
 }
 run().catch(core.setFailed);
@@ -12655,7 +12645,7 @@ exports.visitAsync = visitAsync;
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
 /******/ 	// This entry module is referenced by other modules so it can't be inlined
-/******/ 	var __webpack_exports__ = __nccwpck_require__(7410);
+/******/ 	var __webpack_exports__ = __nccwpck_require__(6099);
 /******/ 	module.exports = __webpack_exports__;
 /******/ 	
 /******/ })()

--- a/hooks/package-auth.sh
+++ b/hooks/package-auth.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+yarn package:auth

--- a/lib/tbot/index.ts
+++ b/lib/tbot/index.ts
@@ -80,6 +80,8 @@ export function baseConfigurationFromSharedInputs(
 export async function writeConfiguration(
   config: ConfigurationV1
 ): Promise<string> {
+  core.debug('Writing tbot configuration:\n' + yaml.stringify(config));
+
   const tempDir = await io.makeTempDirectory();
   const configPath = path.join(tempDir, 'bot-config.yaml');
   const data = yaml.stringify(config);
@@ -88,5 +90,6 @@ export async function writeConfiguration(
 }
 
 export async function execute(configPath: string) {
+  core.info('Invoking tbot with configuration at ' + configPath);
   await exec.exec('tbot', ['start', '-c', configPath]);
 }

--- a/lib/tbot/index.ts
+++ b/lib/tbot/index.ts
@@ -80,11 +80,12 @@ export function baseConfigurationFromSharedInputs(
 export async function writeConfiguration(
   config: ConfigurationV1
 ): Promise<string> {
-  core.debug('Writing tbot configuration:\n' + yaml.stringify(config));
-
   const tempDir = await io.makeTempDirectory();
   const configPath = path.join(tempDir, 'bot-config.yaml');
   const data = yaml.stringify(config);
+
+  core.debug('Writing tbot configuration to ' + configPath);
+  core.debug('Configuration value:\n' + data);
   await fs.writeFile(configPath, data);
   return configPath;
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "eslint": "eslint --ext .ts .",
     "lint": "yarn eslint && yarn prettier-check",
     "package:setup": "ncc build ./setup/index.ts -o dist/setup",
-    "package:auth-k8s": "ncc build ./auth-k8s/index.ts -o dist/auth-k8s"
+    "package:auth-k8s": "ncc build ./auth-k8s/index.ts -o dist/auth-k8s",
+    "package:auth": "ncc build ./auth/index.ts -o dist/auth"
   },
   "dependencies": {
     "@actions/core": "^1.10.0",


### PR DESCRIPTION
Closes #12 

Introduces a GitHub action for fetching credentials for use with `tsh` and `tctl`.

Also partially refactors work introduced in https://github.com/gravitational/teleport-actions/pull/8

Before:

```yaml
 steps:
   - name: Fetch Teleport binaries
     uses: gravitational/teleport-actions/setup@v1
     with:
       version: 11.0.3
   - name: Fetch credentials
     run: >
       tbot start
       --join-method=github
       --token=github-token
       --auth-server=example.domain:443
       --oneshot
       --destination-dir=/opt/machine-id
       --data-dir=/opt/machine-id-data
   - name: List nodes
     run: tsh -i ./opt/machine-id/identity --proxy=example.domain:443 ls
```
After:

```yaml
steps:
  - name: Install Teleport
    uses: gravitational/teleport-actions/setup@v1
    with:
      version: 11.0.3
  - name: Authorize against Teleport
    uses: gravitational/teleport-actions/auth@v1
    with:
      # Specify the publically accessible address of your Teleport proxy.
      proxy: tele.example.com:443
      # Specify the name of the join token for your bot.
      token: my-github-join-token
  - name: List nodes
    run: tsh -i ${{ steps.auth.outputs.identity-file }} ls
```

Once https://github.com/gravitational/teleport/pull/18644 is released providing the path to the identity file when using `tctl` and `tsh` will no longer be necessary.