### PR TITLE
Output both `TELEPORT_AUTH_SERVER` in `auth`

### DIFF
--- a/auth/index.ts
+++ b/auth/index.ts
@@ -23,6 +23,7 @@ async function run() {
   const identityFilePath = path.join(destinationPath, 'identity');
   core.setOutput('identity-file', identityFilePath);
   core.exportVariable('TELEPORT_PROXY', sharedInputs.proxy);
+  core.exportVariable('TELEPORT_AUTH_SERVER', sharedInputs.proxy);
   core.exportVariable('TELEPORT_IDENTITY_FILE', identityFilePath);
 }
 run().catch(core.setFailed);

--- a/dist/auth/index.js
+++ b/dist/auth/index.js
@@ -4016,6 +4016,7 @@ function run() {
         const identityFilePath = path_1.default.join(destinationPath, 'identity');
         core.setOutput('identity-file', identityFilePath);
         core.exportVariable('TELEPORT_PROXY', sharedInputs.proxy);
+        core.exportVariable('TELEPORT_AUTH_SERVER', sharedInputs.proxy);
         core.exportVariable('TELEPORT_IDENTITY_FILE', identityFilePath);
     });
 }


### PR DESCRIPTION
Following https://github.com/gravitational/teleport/pull/18782 `tctl` will ignore `TELEPORT_PROXY`, and hence `auth` needs to also set `TELEPORT_AUTH_SERVER`.